### PR TITLE
Don't `uniq` content references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.2.0
+
+* Don't `uniq` content references ([#6](https://github.com/alphagov/content_block_tools/pull/6))
+
 ## 0.1.0
 
 * Initial release

--- a/lib/content_block_tools/content_block_reference.rb
+++ b/lib/content_block_tools/content_block_reference.rb
@@ -38,9 +38,9 @@ module ContentBlockTools
       #
       # @return [Array<ContentBlockReference>] An array of content block references
       def find_all_in_document(document)
-        document.scan(ContentBlockReference::EMBED_REGEX).map { |match|
+        document.scan(ContentBlockReference::EMBED_REGEX).map do |match|
           ContentBlockReference.new(document_type: match[1], content_id: match[2], embed_code: match[0])
-        }.uniq
+        end
       end
     end
   end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/content_block_tools/content_block_reference_spec.rb
+++ b/spec/content_block_tools/content_block_reference_spec.rb
@@ -49,6 +49,24 @@ RSpec.describe ContentBlockTools::ContentBlockReference do
           expect(result[1].content_id).to eq(content_block_email_address_uuid)
           expect(result[1].embed_code).to eq("{{embed:content_block_email_address:#{content_block_email_address_uuid}}}")
         end
+
+        context "with duplicate references" do
+          let(:document) do
+            """
+              {{embed:contact:#{contact_uuid}}}
+              {{embed:contact:#{contact_uuid}}}
+              {{embed:content_block_email_address:#{content_block_email_address_uuid}}}
+            """
+          end
+
+          it "retains the duplicates" do
+            expect(result.count).to eq(3)
+
+            expect(result[0].content_id).to eq(contact_uuid)
+            expect(result[1].content_id).to eq(contact_uuid)
+            expect(result[2].content_id).to eq(content_block_email_address_uuid)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
In https://github.com/alphagov/publishing-api/pull/2989 we removed the call to `uniq` content references, so we were able to count the number of instances in a page. This replicates this functionality in the gem, so we can move towards using this functionality in Publishing API