### PR TITLE
Loosen Actionview dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.2.1
+
+* Loosen ActionView dependency ([#7](https://github.com/alphagov/content_block_tools/pull/7))
+
 ## 0.2.0
 
 * Don't `uniq` content references ([#6](https://github.com/alphagov/content_block_tools/pull/6))

--- a/content_block_tools.gemspec
+++ b/content_block_tools.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "3.13.0"
   spec.add_development_dependency "rubocop-govuk", "5.0.2"
 
-  spec.add_dependency "actionview", "7.2.2"
+  spec.add_dependency "actionview", ">= 6", "< 7.2.2"
 end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
We won’t be able to install the gem in any repo that doesn’t use this exact version of ActionView (and therefore Rails). Loosening the dependency will help and we can rely on Dependabot to keep the latest version in sync