### PR TITLE
Symbolize keys in content block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
   useful summary for people upgrading their application, not a replication
   of the commit log.
 
+## 0.3.0
+
+* Symbolise details hash ([#8](https://github.com/alphagov/content_block_tools/pull/8))
+
 ## 0.2.1
 
 * Loosen ActionView dependency ([#7](https://github.com/alphagov/content_block_tools/pull/7))

--- a/lib/content_block_tools/content_block.rb
+++ b/lib/content_block_tools/content_block.rb
@@ -48,5 +48,9 @@ module ContentBlockTools
         .fetch(document_type, Presenters::BasePresenter)
         .new(self).render
     end
+
+    def details
+      to_h[:details].symbolize_keys
+    end
   end
 end

--- a/lib/content_block_tools/version.rb
+++ b/lib/content_block_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ContentBlockTools
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/spec/content_block_tools/content_block_spec.rb
+++ b/spec/content_block_tools/content_block_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe ContentBlockTools::ContentBlock do
     expect(content_block.details).to eq(details)
   end
 
+  describe ".details" do
+    let(:details) { { "foo" => "bar" } }
+
+    it "symbolizes the keys" do
+      expect(content_block.details).to eq({ foo: "bar" })
+    end
+  end
+
   describe ".render" do
     let(:render_response) { "SOME_HTML" }
     let(:presenter_double) { double(presenter_class, render: render_response) }


### PR DESCRIPTION
This ensures the content block’s details hash is always in the format we expect, which is useful for rendering. We do this by casting the content block to a hash, fetching the `details` key and calling `symbolize_keys` on the resulting hash.